### PR TITLE
fix: replace Ubuntu PPA with GitHub releases for neovim install

### DIFF
--- a/setup/container-setup.sh
+++ b/setup/container-setup.sh
@@ -25,7 +25,7 @@ if command -v apt-get &>/dev/null; then
     curl -LsSf "https://github.com/neovim/neovim/releases/download/${NVIM_VERSION}/${NVIM_TARBALL}" \
         -o /tmp/nvim.tar.gz
     # Verify checksum from GitHub release asset digest
-    NVIM_SHA256="$(curl -s "https://api.github.com/repos/neovim/neovim/releases/tags/${NVIM_VERSION}" \
+    NVIM_SHA256="$(curl -LsSf "https://api.github.com/repos/neovim/neovim/releases/tags/${NVIM_VERSION}" \
         | jq -r ".assets[] | select(.name == \"${NVIM_TARBALL}\") | .digest" \
         | cut -d: -f2)"
     echo "${NVIM_SHA256}  /tmp/nvim.tar.gz" | sha256sum -c -

--- a/setup/container-setup.sh
+++ b/setup/container-setup.sh
@@ -14,11 +14,16 @@ if command -v apt-get &>/dev/null; then
     apt-get update -qq
     apt-get install -y -qq --no-install-recommends \
         git curl unzip ripgrep fzf nodejs npm
-    # Neovim — use the latest stable PPA on Ubuntu/Debian
-    apt-get install -y -qq --no-install-recommends software-properties-common
-    add-apt-repository -y ppa:neovim-ppa/stable 2>/dev/null \
-        || apt-get install -y -qq neovim
-    apt-get install -y -qq neovim
+    # Neovim — download from GitHub releases (PPA is Ubuntu-only, not available on Debian)
+    case "$(uname -m)" in
+        x86_64)  NVIM_ARCH="x86_64" ;;
+        aarch64) NVIM_ARCH="arm64" ;;
+        *) echo "ERROR: Unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+    esac
+    curl -L "https://github.com/neovim/neovim/releases/latest/download/nvim-linux-${NVIM_ARCH}.tar.gz" \
+        -o /tmp/nvim.tar.gz
+    tar -C /usr/local --strip-components=1 -xzf /tmp/nvim.tar.gz
+    rm /tmp/nvim.tar.gz
     apt-get clean && rm -rf /var/lib/apt/lists/*
 elif command -v apk &>/dev/null; then
     apk add --no-cache neovim git curl ripgrep fzf nodejs npm

--- a/setup/container-setup.sh
+++ b/setup/container-setup.sh
@@ -22,7 +22,7 @@ if command -v apt-get &>/dev/null; then
         *) echo "ERROR: Unsupported architecture: $(uname -m)" >&2; exit 1 ;;
     esac
     NVIM_TARBALL="nvim-linux-${NVIM_ARCH}.tar.gz"
-    curl -L "https://github.com/neovim/neovim/releases/download/${NVIM_VERSION}/${NVIM_TARBALL}" \
+    curl -LsSf "https://github.com/neovim/neovim/releases/download/${NVIM_VERSION}/${NVIM_TARBALL}" \
         -o /tmp/nvim.tar.gz
     # Verify checksum from GitHub release asset digest
     NVIM_SHA256="$(curl -s "https://api.github.com/repos/neovim/neovim/releases/tags/${NVIM_VERSION}" \


### PR DESCRIPTION
## Fix container build failure on Debian-based images

### Problem

Building `container/Dockerfile.example` (based on `python:3.13-slim`, which is Debian) failed with:

```
E: Unable to locate package software-properties-common
```

The bootstrap script was using the Ubuntu PPA workflow to install Neovim:

```bash
apt-get install -y software-properties-common
add-apt-repository -y ppa:neovim-ppa/stable
apt-get install -y neovim
```

`software-properties-common` and PPAs are Ubuntu-specific features. They are not available on Debian, which is the base for `python:*-slim`, `node:*-slim`, and many other official Docker images.

### Fix

Replace the PPA-based installation with a direct download of the Neovim tarball from GitHub Releases, with architecture detection for both `x86_64` and `arm64`:

```bash
case "$(uname -m)" in
    x86_64)  NVIM_ARCH="x86_64" ;;
    aarch64) NVIM_ARCH="arm64" ;;
    *) echo "ERROR: Unsupported architecture: $(uname -m)" >&2; exit 1 ;;
esac
curl -L "https://github.com/neovim/neovim/releases/latest/download/nvim-linux-${NVIM_ARCH}.tar.gz" \
    -o /tmp/nvim.tar.gz
tar -C /usr/local --strip-components=1 -xzf /tmp/nvim.tar.gz
rm /tmp/nvim.tar.gz
```

This approach:
- Works on both **Debian and Ubuntu** based images without any extra dependencies
- Supports **amd64 and arm64** (Apple Silicon, Graviton, Raspberry Pi, etc.)
- Always installs the **latest stable release** of Neovim

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container setup to install Neovim from official GitHub releases instead of the previous apt/PPA approach. Adds automatic architecture detection (x86_64, arm64), checksum verification of the downloaded release, and explicit error handling for unsupported architectures. Preserves other package installations and removes the apt-based Neovim fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->