### PR TITLE
fix: add lazy=false and priority=1000 to tokyodark colorscheme

### DIFF
--- a/nvim/lua/plugins/tokyodark.lua
+++ b/nvim/lua/plugins/tokyodark.lua
@@ -1,5 +1,7 @@
 return {
     "tiagovla/tokyodark.nvim",
+    lazy = false,
+    priority = 1000,
     opts = {
         -- custom options here
     },


### PR DESCRIPTION
## Summary

- Adds `lazy = false` and `priority = 1000` to tokyodark colorscheme plugin spec
- Prevents flash of unstyled content (FOUC) on startup per Lazy.nvim best practices

Closes #20

## Test plan

- [x] `make check` passes (lint, format, complexity, tests)
- [ ] Visual: open nvim and confirm no FOUC on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Tokyo Dark theme plugin configuration to load eagerly with higher priority, improving editor initialization performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->